### PR TITLE
FEATURE: Make PHPDoc tags configurable

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -119,3 +119,16 @@ the provided one.
           <property name="legacyExtensions" type="array" value="Extbase,Fluid,Frontend,Core"/>
       </properties>
   </rule>
+
+Typo3Update.LegacyClassnames.DocComment: ``allowedTags``
+    Configures which tags are checked for legacy class names.
+
+    Example:
+
+.. code:: xml
+
+   <rule ref="Typo3Update.LegacyClassnames.DocComment">
+       <properties>
+           <property name="allowedTags" type="array" value="@param,@return,@var,@see,@throws"/>
+       </properties>
+   </rule>

--- a/src/Standards/Typo3Update/Sniffs/LegacyClassnames/DocCommentSniff.php
+++ b/src/Standards/Typo3Update/Sniffs/LegacyClassnames/DocCommentSniff.php
@@ -32,7 +32,7 @@ class Typo3Update_Sniffs_LegacyClassnames_DocCommentSniff implements PHP_CodeSni
      * The configured tags will be processed.
      * @var array<string>
      */
-    protected $allowedTags = ['@param', '@return', '@var'];
+    public $allowedTags = ['@param', '@return', '@var'];
 
     /**
      * Original token content for reuse accross methods.

--- a/src/Standards/Typo3Update/ruleset.xml
+++ b/src/Standards/Typo3Update/ruleset.xml
@@ -7,4 +7,9 @@
             <property name="legacyExtensions" type="array" value="Extbase,Fluid,Frontend,Core"/>
         </properties>
     </rule>
+    <rule ref="Typo3Update.LegacyClassnames.DocComment">
+        <properties>
+            <property name="allowedTags" type="array" value="@param,@return,@var,@see,@throws"/>
+        </properties>
+    </rule>
 </ruleset>


### PR DESCRIPTION
* Make them configurable in Sniff.
* Extend readme with new configuration option.
* Provide example in ruleset.xml

Resolves: #25, #24, #23