### PR TITLE
BUGFIX: Update string to replace missing vendor token

### DIFF
--- a/src/Standards/Typo3Update/Sniffs/LegacyClassnames/MissingVendorForPluginsAndModulesSniff.php
+++ b/src/Standards/Typo3Update/Sniffs/LegacyClassnames/MissingVendorForPluginsAndModulesSniff.php
@@ -78,7 +78,7 @@ class Typo3Update_Sniffs_LegacyClassnames_MissingVendorForPluginsAndModulesSniff
         if ($fix === true) {
             $phpcsFile->fixer->replaceToken(
                 $firstArgument,
-                "'{Options::getVendor()}.' . {$tokens[$firstArgument]['content']}"
+                "'" . Options::getVendor() . ".' . " . $tokens[$firstArgument]['content']
             );
         }
     }


### PR DESCRIPTION
* Using double quotes with method call didn't work the way.
* Use normal string concatenation instead.